### PR TITLE
feat: 마이페이지 수정 및 프로필 이미지 관리 기능 추가

### DIFF
--- a/src/main/java/thonlivethondie/artconnect/controller/MyPageController.java
+++ b/src/main/java/thonlivethondie/artconnect/controller/MyPageController.java
@@ -1,0 +1,44 @@
+package thonlivethondie.artconnect.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import thonlivethondie.artconnect.dto.MyPageResponse;
+import thonlivethondie.artconnect.dto.MyPageUpdateRequest;
+import thonlivethondie.artconnect.service.MyPageService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(myPageService.getMyPage(userId));
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateMyPage(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody MyPageUpdateRequest request
+    ) {
+        myPageService.updateMyPage(userId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/profile-image")
+    public ResponseEntity<Void> updateProfileImage(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam String imageName,
+            @RequestParam String imageUrl,
+            @RequestParam Long imageSize,
+            @RequestParam String imageType
+    ) {
+        myPageService.updateProfileImage(userId, imageName, imageUrl, imageSize, imageType);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/thonlivethondie/artconnect/dto/MyPageResponse.java
+++ b/src/main/java/thonlivethondie/artconnect/dto/MyPageResponse.java
@@ -1,0 +1,18 @@
+package thonlivethondie.artconnect.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MyPageResponse {
+    private String nickname;         // 변경 불가
+    private String email;            // 변경 불가
+    private String phoneNumber;      // 변경 가능
+    private String education;           // 변경 가능
+    private String major;            // 변경 가능
+    private List<String> specialty; // 최대 3개 선택 가능
+    private String imageUrl;  // 프로필 이미지 경로
+}

--- a/src/main/java/thonlivethondie/artconnect/dto/MyPageUpdateRequest.java
+++ b/src/main/java/thonlivethondie/artconnect/dto/MyPageUpdateRequest.java
@@ -1,0 +1,18 @@
+package thonlivethondie.artconnect.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MyPageUpdateRequest {
+
+    private String phoneNumber;
+    private String education;
+    private String major;
+
+    @Size(max = 3, message = "전문 분야는 최대 3개까지 선택 가능합니다.")
+    private List<String> specialty;
+}

--- a/src/main/java/thonlivethondie/artconnect/entity/Store.java
+++ b/src/main/java/thonlivethondie/artconnect/entity/Store.java
@@ -58,6 +58,7 @@ public class Store extends BaseEntity {
     public void updateStoreInfo(String storeName, String address, String phoneNumber, String operatingHours) {
         if (storeName != null) {
             this.storeName = storeName;
+            this.user.updateNickname(storeName);
         }
         if (address != null) {
             this.address = address;

--- a/src/main/java/thonlivethondie/artconnect/entity/User.java
+++ b/src/main/java/thonlivethondie/artconnect/entity/User.java
@@ -58,9 +58,21 @@ public class User extends BaseEntity {
 
     private String socialId;
 
+    private String refreshToken;
+
+    // 사용자 프로필 이미지
+    @Column(name = "image_name")
+    private String imageName;
+
+    @Column(name = "image_url")
     private String imageUrl;
 
-    private String refreshToken;
+    @Column(name = "image_size")
+    private Long imageSize;
+
+    @Column(name = "image_type")
+    private String imageType;
+
 
     // 디자이너인 경우 포트폴리오 목록
     @OneToMany(mappedBy = "designer", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -98,16 +110,41 @@ public class User extends BaseEntity {
     }
 
     public void updateDesignerInfo(String education, String major, String specialty) {
-        if (education != null) {
+        if (education != null && !education.trim().isEmpty()) {
             this.education = education;
         }
 
-        if (major != null) {
+        if (major != null && !major.trim().isEmpty()) {
             this.major = major;
         }
 
-        if (specialty != null) {
+        if (specialty != null && !specialty.trim().isEmpty()) {
             this.specialty = specialty;
+        }
+    }
+
+    public void updateNickname(String nickname) {
+        if (nickname != null && !nickname.trim().isEmpty()) {
+            this.nickname = nickname;
+        }
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void updateProfileImage(String imageName, String imageUrl, Long imageSize, String imageType) {
+        if (imageName != null && !imageName.trim().isEmpty()) {
+            this.imageName = imageName;
+        }
+        if (imageUrl != null && !imageUrl.trim().isEmpty()) {
+            this.imageUrl = imageUrl;
+        }
+        if (imageSize != null) {
+            this.imageSize = imageSize;
+        }
+        if (imageType != null && !imageType.trim().isEmpty()) {
+            this.imageType = imageType;
         }
     }
 }

--- a/src/main/java/thonlivethondie/artconnect/service/MyPageService.java
+++ b/src/main/java/thonlivethondie/artconnect/service/MyPageService.java
@@ -1,0 +1,93 @@
+package thonlivethondie.artconnect.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import thonlivethondie.artconnect.dto.MyPageResponse;
+import thonlivethondie.artconnect.dto.MyPageUpdateRequest;
+import thonlivethondie.artconnect.entity.User;
+import thonlivethondie.artconnect.repository.UserRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+
+    // 허용된 전문분야 목록
+    private static final List<String> ALLOWED_SPECIALTIES = List.of(
+            "로고 디자인",
+            "브랜드 디자인",
+            "굿즈 디자인",
+            "포스터&전단지 디자인",
+            "배너&광고 디자인",
+            "패키지 디자인",
+            "명함&카드&인쇄물 디자인"
+    );
+
+    @Transactional(readOnly = true)
+    public MyPageResponse getMyPage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<String> specialty = user.getSpecialty() != null
+                ? Arrays.asList(user.getSpecialty().split(","))
+                : List.of();
+
+        return MyPageResponse.builder()
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .phoneNumber(user.getPhoneNumber())
+                .education(user.getEducation())
+                .major(user.getMajor())
+                .specialty(specialty)
+                .imageUrl(user.getImageUrl())
+                .build();
+    }
+
+    @Transactional
+    public void updateMyPage(Long userId, MyPageUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        String updatedEducation = request.getEducation() != null ? request.getEducation() : user.getEducation();
+        String updatedMajor = request.getMajor() != null ? request.getMajor() : user.getMajor();
+
+        // specialty는 null/빈값이면 기존 값 유지
+        String updatedSpecialty;
+
+        // 전문분야 검증
+        if (request.getSpecialty() != null && !request.getSpecialty().isEmpty()) {
+            if (request.getSpecialty().size() > 3) {
+                throw new IllegalArgumentException("전문 분야는 최대 3개까지만 선택 가능합니다.");
+            }
+            for (String specialty : request.getSpecialty()) {
+                if (!ALLOWED_SPECIALTIES.contains(specialty)) {
+                    throw new IllegalArgumentException("허용되지 않은 전문 분야입니다: " + specialty);
+                }
+            }
+            updatedSpecialty = String.join(",", request.getSpecialty());
+        } else {
+            updatedSpecialty = user.getSpecialty();
+        }
+
+        // 값 업데이트
+        user.updateDesignerInfo(updatedEducation, updatedMajor, updatedSpecialty);
+
+        // phoneNumber는 null이면 유지
+        if (request.getPhoneNumber() != null) {
+            user.setPhoneNumber(request.getPhoneNumber());
+        }
+    }
+
+    @Transactional
+    public void updateProfileImage(Long userId, String imageName, String imageUrl, Long imageSize, String imageType) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        user.updateProfileImage(imageName, imageUrl, imageSize, imageType);
+    }
+}


### PR DESCRIPTION
1. 내 정보 수정 API 
- education, major, specialty, phoneNumber 수정 가능
- null 또는 빈 값 전달 시 기존 값 유지
-전문분야(specialty)는 최대 3개까지 선택 가능하며, 허용된 목록 외 값은 예외 처리


2. 프로필 이미지 수정 API 추가 
- 프로필 이미지 1장 관리 


3. 소상공인 유저 닉네임 연동 기능 추가
- 유저 타입이 소상공인일 경우, Store 닉네임 변경 시 User 닉네임도 함께 변경되도록 수정