### PR TITLE
[FEAT] 포트폴리오 기능 완성

### DIFF
--- a/src/main/java/thonlivethondie/artconnect/common/DesignStyle.java
+++ b/src/main/java/thonlivethondie/artconnect/common/DesignStyle.java
@@ -4,12 +4,21 @@ import lombok.Getter;
 
 @Getter
 public enum DesignStyle {
-    MINIMAL("미니멀"),
-    MODERN("모던"),
-    CLASSIC("클래식"),
+    SIMPLE("심플한"),
+    WARM("따뜻한"),
+    FANCY("화려한"),
+    NEAT("산뜻한"),
+    TRANQUIL("차분한"),
     VINTAGE("빈티지"),
-    ILLUSTRATION("일러스트"),
-    TYPOGRAPHY("타이포그래피");
+    RETRO("레트로"),
+    CUTE("귀여운"),
+    LOVELY("러블리"),
+    REFRESHING("청량한"),
+    NATURAL("자연스러운"),
+    LUXURIOUS("고급스러운"),
+    MODERN("현대적인"),
+    CLASSIC("클래식한"),
+    EMOTIONAL("감성적인");
 
     private final String description;
 

--- a/src/main/java/thonlivethondie/artconnect/common/exception/ErrorCode.java
+++ b/src/main/java/thonlivethondie/artconnect/common/exception/ErrorCode.java
@@ -9,7 +9,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public enum ErrorCode {
     EMAIL_DUPLICATED(BAD_REQUEST, "E001", "중복된 이메일입니다."),
     VALIDATION_ERROR(BAD_REQUEST, "E002", "입력값 검증에 실패했습니다."),
-    
+
     // 사용자 관련 에러
     USER_NOT_FOUND(BAD_REQUEST, "U001", "사용자를 찾을 수 없습니다."),
 
@@ -18,15 +18,21 @@ public enum ErrorCode {
     ALREADY_HAS_STORE(BAD_REQUEST, "S002", "이미 매장을 보유하고 있습니다."),
     DUPLICATE_STORE_NAME(BAD_REQUEST, "S003", "이미 존재하는 매장명입니다."),
     STORE_NOT_FOUND(BAD_REQUEST, "S004", "매장을 찾을 수 없습니다."),
-    STORE_ACCESS_DENIED(BAD_REQUEST,"S005", "해당 매장에 접근할 권한이 없습니다."),
+    STORE_ACCESS_DENIED(BAD_REQUEST, "S005", "해당 매장에 접근할 권한이 없습니다."),
     STORE_IMAGE_NOT_FOUND(BAD_REQUEST, "S006", "매장 이미지를 찾을 수 없습니다."),
     STORE_IMAGE_ACCESS_DENIED(BAD_REQUEST, "S007", "해당 매장 이미지에 접근할 권한이 없습니다."),
-    
+
     // 작업의뢰서 관련 에러
-    WORK_REQUEST_NOT_FOUND(BAD_REQUEST,"W001", "작업의뢰서를 찾을 수 없습니다."),
-    WORK_REQUEST_ACCESS_DENIED(BAD_REQUEST,"W002", "작업의뢰서에 접근할 권한이 없습니다."),
-    IMAGE_UPLOAD_FAILED(BAD_REQUEST,"I001", "이미지 업로드에 실패했습니다."),
-    
+    WORK_REQUEST_NOT_FOUND(BAD_REQUEST, "W001", "작업의뢰서를 찾을 수 없습니다."),
+    WORK_REQUEST_ACCESS_DENIED(BAD_REQUEST, "W002", "작업의뢰서에 접근할 권한이 없습니다."),
+    IMAGE_UPLOAD_FAILED(BAD_REQUEST, "I001", "이미지 업로드에 실패했습니다."),
+
+    // 포트폴리오 에러
+    PORTFOLIO_NOT_FOUND(BAD_REQUEST, "P001", "포트폴리오를 찾을 수 없습니다."),
+    PORTFOLIO_ACCESS_DENIED(BAD_REQUEST, "P002", "해당 포트폴리오에 접근할 권한이 없습니다."),
+    PORTFOLIO_IMAGE_NOT_FOUND(BAD_REQUEST, "P003", "포트폴리오 이미지를 찾을 수 없습니다"),
+    PORTFOLIO_IMAGE_ACCESS_DENIED(BAD_REQUEST, "P004", "포트폴리오 이미지에 접근할 권한이 없습니다."),
+
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E999", "서버 내부 오류가 발생했습니다.");
 
     private HttpStatus status;

--- a/src/main/java/thonlivethondie/artconnect/controller/MyPageController.java
+++ b/src/main/java/thonlivethondie/artconnect/controller/MyPageController.java
@@ -10,10 +10,6 @@ import thonlivethondie.artconnect.dto.DesignerMyPageUpdateRequest;
 import thonlivethondie.artconnect.service.MyPageService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
-/**
- * 마이페이지 통합 컨트롤러
- * 사용자 타입(디자이너/소상공인)에 관계없이 동일한 엔드포인트 제공
- */
 @RestController
 @RequestMapping("/api/mypage")
 @RequiredArgsConstructor

--- a/src/main/java/thonlivethondie/artconnect/controller/PortfolioController.java
+++ b/src/main/java/thonlivethondie/artconnect/controller/PortfolioController.java
@@ -1,0 +1,142 @@
+package thonlivethondie.artconnect.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import thonlivethondie.artconnect.dto.PortfolioRequestDto;
+import thonlivethondie.artconnect.dto.PortfolioResponseDto;
+import thonlivethondie.artconnect.service.PortfolioService;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/portfolios")
+@RequiredArgsConstructor
+public class PortfolioController {
+
+    private final PortfolioService portfolioService;
+
+    /**
+     * 새 포트폴리오 생성
+     */
+    @PostMapping
+    public ResponseEntity<PortfolioResponseDto> createPortfolio(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid PortfolioRequestDto request) {
+
+        // UserDetails에서 userId 추출
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        PortfolioResponseDto response = portfolioService.createPortfolio(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 포트폴리오 업데이트
+     */
+    @PutMapping("/{portfolioId}")
+    public ResponseEntity<PortfolioResponseDto> updatePortfolio(
+            @PathVariable Long portfolioId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid PortfolioRequestDto request) {
+
+        // UserDetails에서 userId 추출
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        PortfolioResponseDto response = portfolioService.updatePortfolio(userId, portfolioId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 내 포트폴리오 목록 조회
+     */
+    @GetMapping("/my")
+    public ResponseEntity<List<PortfolioResponseDto>> getMyPortfolios(@AuthenticationPrincipal UserDetails userDetails) {
+
+        // UserDetails에서 userId 추출
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        List<PortfolioResponseDto> portfolios = portfolioService.getMyPortfolios(userId);
+
+        return ResponseEntity.ok(portfolios);
+    }
+
+    /**
+     * 특정 포트폴리오 조회
+     */
+    @GetMapping("/{portfolioId}")
+    public ResponseEntity<PortfolioResponseDto> getPortfolio(
+            @PathVariable Long portfolioId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        // UserDetails에서 userId 추출
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        PortfolioResponseDto portfolio = portfolioService.getPortfolio(userId, portfolioId);
+
+        return ResponseEntity.ok(portfolio);
+    }
+
+    /**
+     * 포트폴리오 삭제
+     */
+    @DeleteMapping("/{portfolioId}")
+    public ResponseEntity<Void> deletePortfolio(
+            @PathVariable Long portfolioId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        // UserDetails에서 userId 추출
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        portfolioService.deletePortfolio(userId, portfolioId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 포트폴리오 이미지 업로드
+     */
+    @PostMapping("/{portfolioId}/images")
+    public ResponseEntity<PortfolioResponseDto> uploadPortfolioImages(
+            @PathVariable Long portfolioId,
+            @RequestPart("images") List<MultipartFile> images,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        // UserDetails에서 userId 추출
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        log.info("포트폴리오 이미지 업로드 요청 - userId: {}, portfolioId: {}, 이미지 개수: {}", userId, portfolioId, images.size());
+
+        PortfolioResponseDto response = portfolioService.uploadPortfolioImages(userId, portfolioId, images);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 포트폴리오 이미지 삭제
+     */
+    @DeleteMapping("/{portfolioId}/images/{imageId}")
+    public ResponseEntity<PortfolioResponseDto> deletePortfolioImage(
+            @PathVariable Long portfolioId,
+            @PathVariable Long imageId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        // UserDetails에서 userId 추출
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        log.info("포트폴리오 이미지 삭제 요청 - userId: {}, portfolioId: {}, imageId: {}", userId, portfolioId, imageId);
+
+        PortfolioResponseDto response = portfolioService.deletePortfolioImage(userId, portfolioId, imageId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/thonlivethondie/artconnect/dto/PortfolioImageDto.java
+++ b/src/main/java/thonlivethondie/artconnect/dto/PortfolioImageDto.java
@@ -1,0 +1,42 @@
+package thonlivethondie.artconnect.dto;
+
+import thonlivethondie.artconnect.entity.PortfolioImage;
+
+public record PortfolioImageDto(
+        Long id,
+        String imageName,
+        String imageUrl,
+        Long imageSize,
+        Boolean isThumbnail
+) {
+    public static PortfolioImageDto from(PortfolioImage portfolioImage) {
+        return new PortfolioImageDto(
+                portfolioImage.getId(),
+                portfolioImage.getImageName(),
+                portfolioImage.getImageUrl(),
+                portfolioImage.getImageSize(),
+                portfolioImage.getIsThumbnail()
+        );
+    }
+
+    // 편의 메서드들
+    public String getFormattedSize() {
+        if (imageSize == null) return "알 수 없음";
+
+        if (imageSize < 1024) {
+            return imageSize + " B";
+        } else if (imageSize < 1024 * 1024) {
+            return String.format("%.1f KB", imageSize / 1024.0);
+        } else {
+            return String.format("%.1f MB", imageSize / (1024.0 * 1024.0));
+        }
+    }
+
+    public String getFileExtension() {
+        if (imageName == null || imageName.isEmpty()) {
+            return "";
+        }
+        int lastDot = imageName.lastIndexOf('.');
+        return lastDot > 0 ? imageName.substring(lastDot + 1).toLowerCase() : "";
+    }
+}

--- a/src/main/java/thonlivethondie/artconnect/dto/PortfolioRequestDto.java
+++ b/src/main/java/thonlivethondie/artconnect/dto/PortfolioRequestDto.java
@@ -1,0 +1,19 @@
+package thonlivethondie.artconnect.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import thonlivethondie.artconnect.common.DesignCategory;
+
+import java.util.List;
+
+public record PortfolioRequestDto(
+        @NotBlank(message = "포트폴리오 제목은 필수입니다.")
+        @Size(max = 200, message = "포트폴리오 제목은 200자 이하여야 합니다.")
+        String title,
+
+        @Size(max = 3, message = "디자인 카테고리는 최대 3개까지 선택 가능합니다.")
+        List<DesignCategory> designCategories,
+
+        String description
+) {
+}

--- a/src/main/java/thonlivethondie/artconnect/dto/PortfolioResponseDto.java
+++ b/src/main/java/thonlivethondie/artconnect/dto/PortfolioResponseDto.java
@@ -1,0 +1,62 @@
+package thonlivethondie.artconnect.dto;
+
+import lombok.Builder;
+import thonlivethondie.artconnect.common.DesignCategory;
+import thonlivethondie.artconnect.entity.Portfolio;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record PortfolioResponseDto(
+        Long portfolioId,
+        Long designerId,
+        String designerNickname,
+        String title,
+        String description,
+        List<DesignCategory> designCategories,
+        List<PortfolioImageDto> portfolioImages,
+        String thumbnailUrl,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public PortfolioResponseDto {
+        // 불변성을 위한 방어적 복사
+        designCategories = designCategories != null ? List.copyOf(designCategories) : List.of();
+        portfolioImages = portfolioImages != null ? List.copyOf(portfolioImages) : List.of();
+    }
+
+    public static PortfolioResponseDto from(Portfolio portfolio) {
+        return PortfolioResponseDto.builder()
+                .portfolioId(portfolio.getId())
+                .designerId(portfolio.getDesigner().getId())
+                .designerNickname(portfolio.getDesigner().getNickname())
+                .title(portfolio.getTitle())
+                .description(portfolio.getDescription())
+                .designCategories(portfolio.getSelectedDesignCategories())
+                .portfolioImages(portfolio.getPortfolioImages().stream()
+                        .map(PortfolioImageDto::from)
+                        .toList())
+                .thumbnailUrl(portfolio.getThumbnailUrl())
+                .createdAt(portfolio.getCreateDate())
+                .updatedAt(portfolio.getUpdatedDate())
+                .build();
+    }
+
+    // 편의 메서드들
+    public boolean hasImages() {
+        return !portfolioImages.isEmpty();
+    }
+
+    public int getImageCount() {
+        return portfolioImages.size();
+    }
+
+    public boolean hasThumbnail() {
+        return thumbnailUrl != null && !thumbnailUrl.isEmpty();
+    }
+
+    public int getCategoryCount() {
+        return designCategories.size();
+    }
+}

--- a/src/main/java/thonlivethondie/artconnect/entity/Portfolio.java
+++ b/src/main/java/thonlivethondie/artconnect/entity/Portfolio.java
@@ -75,31 +75,14 @@ public class Portfolio extends BaseEntity {
 
         // 새 카테고리들 추가
         for (DesignCategory category : categories) {
-            this.addDesignCategory(category);
+            PortfolioDesignCategory portfolioDesignCategory =
+                    PortfolioDesignCategory.builder()
+                            .portfolio(this)
+                            .designCategory(category)
+                            .build();
+
+            this.designCategories.add(portfolioDesignCategory);
         }
-    }
-
-    // 디자인 카테고리 추가 메서드
-    public void addDesignCategory(DesignCategory category) {
-        if (this.designCategories.size() >= 3) {
-            throw new IllegalArgumentException("최대 3개의 디자인 카테고리만 선택할 수 있습니다.");
-        }
-
-        // 중복 체크
-        boolean exists = this.designCategories.stream()
-                .anyMatch(dc -> dc.getDesignCategory() == category);
-
-        if (exists) {
-            throw new IllegalArgumentException("이미 선택된 디자인 카테고리입니다.");
-        }
-
-        PortfolioDesignCategory portfolioDesignCategory =
-                PortfolioDesignCategory.builder()
-                        .portfolio(this)
-                        .designCategory(category)
-                        .build();
-
-        this.designCategories.add(portfolioDesignCategory);
     }
 
     // 디자인 카테고리 제거 메서드
@@ -112,5 +95,24 @@ public class Portfolio extends BaseEntity {
         return this.designCategories.stream()
                 .map(PortfolioDesignCategory::getDesignCategory)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 포트폴리오 정보 업데이트
+     */
+    public void updatePortfolioInfo(String title, String description) {
+        if (title != null && !title.trim().isEmpty()) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+    }
+
+    /**
+     * 썸네일 URL 업데이트
+     */
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
     }
 }

--- a/src/main/java/thonlivethondie/artconnect/entity/PortfolioImage.java
+++ b/src/main/java/thonlivethondie/artconnect/entity/PortfolioImage.java
@@ -30,9 +30,6 @@ public class PortfolioImage extends BaseEntity {
     @Column(name = "image_size")
     private Long imageSize; // 파일 크기 (bytes)
 
-    @Column(name = "display_order", nullable = false)
-    private Integer displayOrder; // 이미지 표시 순서
-
     @Column(name = "is_thumbnail", columnDefinition = "BOOLEAN DEFAULT false")
     private Boolean isThumbnail = false; // 썸네일 여부
 
@@ -41,13 +38,11 @@ public class PortfolioImage extends BaseEntity {
                           String imageUrl,
                           String imageName,
                           Long imageSize,
-                          Integer displayOrder,
                           Boolean isThumbnail) {
         this.portfolio = portfolio;
         this.imageUrl = imageUrl;
         this.imageName = imageName;
         this.imageSize = imageSize;
-        this.displayOrder = displayOrder;
         this.isThumbnail = isThumbnail != null ? isThumbnail : false;
     }
 }

--- a/src/main/java/thonlivethondie/artconnect/entity/UserDesignCategory.java
+++ b/src/main/java/thonlivethondie/artconnect/entity/UserDesignCategory.java
@@ -5,13 +5,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import thonlivethondie.artconnect.common.BaseTimeEntity;
 import thonlivethondie.artconnect.common.DesignCategory;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user_design_categories")
-public class UserDesignCategory {
+public class UserDesignCategory extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/thonlivethondie/artconnect/entity/UserDesignStyleCategory.java
+++ b/src/main/java/thonlivethondie/artconnect/entity/UserDesignStyleCategory.java
@@ -5,13 +5,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import thonlivethondie.artconnect.common.BaseTimeEntity;
 import thonlivethondie.artconnect.common.DesignStyle;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user_design_style_categories")
-public class UserDesignStyleCategory {
+public class UserDesignStyleCategory extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/thonlivethondie/artconnect/repository/PortfolioImageRepository.java
+++ b/src/main/java/thonlivethondie/artconnect/repository/PortfolioImageRepository.java
@@ -1,0 +1,19 @@
+package thonlivethondie.artconnect.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import thonlivethondie.artconnect.entity.PortfolioImage;
+
+import java.util.List;
+
+public interface PortfolioImageRepository extends JpaRepository<PortfolioImage, Long> {
+
+    /**
+     * 특정 포트폴리오의 모든 이미지의 썸네일 상태를 false로 설정하고, 특정 이미지만 true로 설정
+     */
+    @Modifying
+    @Query("UPDATE PortfolioImage pi SET pi.isThumbnail = CASE WHEN pi.id = :imageId THEN true ELSE false END WHERE pi.portfolio.id = :portfolioId")
+    void updateThumbnailStatus(@Param("portfolioId") Long portfolioId, @Param("imageId") Long imageId);
+}

--- a/src/main/java/thonlivethondie/artconnect/repository/PortfolioRepository.java
+++ b/src/main/java/thonlivethondie/artconnect/repository/PortfolioRepository.java
@@ -1,7 +1,16 @@
 package thonlivethondie.artconnect.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import thonlivethondie.artconnect.entity.Portfolio;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long>, PortfolioRepositoryCustom {
+
+    List<Portfolio> findByDesignerId(Long designerId);
+
+    long countByDesignerId(Long designerId);
 }

--- a/src/main/java/thonlivethondie/artconnect/service/PortfolioService.java
+++ b/src/main/java/thonlivethondie/artconnect/service/PortfolioService.java
@@ -1,0 +1,310 @@
+package thonlivethondie.artconnect.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import thonlivethondie.artconnect.common.UserType;
+import thonlivethondie.artconnect.common.exception.BadRequestException;
+import thonlivethondie.artconnect.common.exception.ErrorCode;
+import thonlivethondie.artconnect.dto.PortfolioRequestDto;
+import thonlivethondie.artconnect.dto.PortfolioResponseDto;
+import thonlivethondie.artconnect.entity.Portfolio;
+import thonlivethondie.artconnect.entity.PortfolioImage;
+import thonlivethondie.artconnect.entity.User;
+import thonlivethondie.artconnect.repository.PortfolioImageRepository;
+import thonlivethondie.artconnect.repository.PortfolioRepository;
+import thonlivethondie.artconnect.repository.UserRepository;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PortfolioService {
+
+    private final PortfolioRepository portfolioRepository;
+    private final PortfolioImageRepository portfolioImageRepository;
+    private final UserRepository userRepository;
+    private final AwsS3Service awsS3Service;
+
+    /**
+     * 새 포트폴리오 생성
+     */
+    public PortfolioResponseDto createPortfolio(Long userId, PortfolioRequestDto request) {
+        User designer = validateDesigner(userId);
+        Portfolio portfolio = createNewPortfolio(designer, request);
+        return PortfolioResponseDto.from(portfolio);
+    }
+
+    /**
+     * 포트폴리오 업데이트
+     */
+    public PortfolioResponseDto updatePortfolio(Long userId, Long portfolioId, PortfolioRequestDto request) {
+        validateDesigner(userId);
+        Portfolio portfolio = getPortfolioByIdAndUserId(portfolioId, userId);
+        portfolio = updatePortfolioInfo(portfolio, request);
+        return PortfolioResponseDto.from(portfolio);
+    }
+
+    /**
+     * 포트폴리오 이미지 업로드
+     */
+    public PortfolioResponseDto uploadPortfolioImages(Long userId, Long portfolioId, List<MultipartFile> images) {
+        validateDesigner(userId);
+        Portfolio portfolio = getPortfolioByIdAndUserId(portfolioId, userId);
+
+        log.info("포트폴리오 이미지 업로드 시작 - portfolioId: {}, 이미지 개수: {}", portfolio.getId(), images.size());
+
+        // 빈 파일 필터링
+        List<MultipartFile> validImages = images.stream()
+                .filter(image -> !image.isEmpty())
+                .toList();
+
+        if (validImages.isEmpty()) {
+            log.warn("업로드할 유효한 이미지가 없습니다.");
+            return PortfolioResponseDto.from(portfolio);
+        }
+
+        try {
+            // S3에 이미지 업로드
+            List<String> imageUrls = awsS3Service.uploadFile(validImages);
+            log.info("S3 업로드 완료 - 업로드된 URL 개수: {}", imageUrls.size());
+
+            // 현재 이미지가 없는 경우 첫 번째 업로드 이미지를 썸네일로 설정
+            boolean isFirstImageUpload = portfolio.getPortfolioImages().isEmpty();
+
+            // PortfolioImage 엔티티 생성 및 저장
+            for (int i = 0; i < validImages.size() && i < imageUrls.size(); i++) {
+                MultipartFile image = validImages.get(i);
+                String imageUrl = imageUrls.get(i);
+
+                PortfolioImage portfolioImage = PortfolioImage.builder()
+                        .portfolio(portfolio)
+                        .imageName(image.getOriginalFilename())
+                        .imageUrl(imageUrl)
+                        .imageSize(image.getSize())
+                        .isThumbnail(isFirstImageUpload && i == 0) // 첫 번째 업로드 시 첫 번째 이미지를 썸네일로 설정
+                        .build();
+
+                portfolio.getPortfolioImages().add(portfolioImage);
+                log.info("포트폴리오 이미지 엔티티 생성 - 파일명: {}, URL: {}, 크기: {}",
+                        image.getOriginalFilename(), imageUrl, image.getSize());
+            }
+
+            // 썸네일 URL 업데이트 (첫 번째 업로드인 경우)
+            if (isFirstImageUpload && !portfolio.getPortfolioImages().isEmpty()) {
+                // 첫 번째 이미지의 URL을 썸네일로 설정
+                String firstImageUrl = portfolio.getPortfolioImages().get(0).getImageUrl();
+                portfolio.updateThumbnailUrl(firstImageUrl);
+            }
+
+            Portfolio savedPortfolio = portfolioRepository.save(portfolio);
+            log.info("포트폴리오 이미지 업로드 완료 - 총 이미지 수: {}", savedPortfolio.getPortfolioImages().size());
+
+            return PortfolioResponseDto.from(savedPortfolio);
+
+        } catch (Exception e) {
+            log.error("포트폴리오 이미지 업로드 실패", e);
+            throw new BadRequestException(ErrorCode.IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * 포트폴리오 이미지 삭제
+     */
+    @Transactional
+    public PortfolioResponseDto deletePortfolioImage(Long userId, Long portfolioId, Long imageId) {
+        validateDesigner(userId);
+        Portfolio portfolio = getPortfolioByIdAndUserId(portfolioId, userId);
+
+        // 이미지 찾기 및 권한 확인
+        PortfolioImage portfolioImage = portfolioImageRepository.findById(imageId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.PORTFOLIO_IMAGE_NOT_FOUND));
+
+        if (!portfolioImage.getPortfolio().getId().equals(portfolio.getId())) {
+            throw new BadRequestException(ErrorCode.PORTFOLIO_IMAGE_ACCESS_DENIED);
+        }
+
+        // S3에서 이미지 삭제
+        try {
+            String fileName = extractFileNameFromUrl(portfolioImage.getImageUrl());
+            awsS3Service.deleteFile(fileName);
+        } catch (Exception e) {
+            log.warn("S3 이미지 삭제 실패: {}", portfolioImage.getImageUrl(), e);
+        }
+
+        // 삭제할 이미지가 썸네일인지 또는 썸네일 URL과 일치하는지 확인
+        boolean deletingThumbnail = portfolioImage.getIsThumbnail();
+        boolean thumbnailUrlMatches = portfolio.getThumbnailUrl() != null &&
+                portfolio.getThumbnailUrl().equals(portfolioImage.getImageUrl());
+
+        // 데이터베이스에서 삭제
+        portfolio.getPortfolioImages().remove(portfolioImage);
+        portfolioImageRepository.delete(portfolioImage);
+
+        // 썸네일 이미지를 삭제한 경우 또는 썸네일 URL이 삭제되는 이미지와 같은 경우, 새로운 썸네일 설정
+        if ((deletingThumbnail || thumbnailUrlMatches) && !portfolio.getPortfolioImages().isEmpty()) {
+            updateThumbnailToFirstImage(portfolio);
+            log.info("썸네일 재설정 - 삭제된 이미지 URL: {}", portfolioImage.getImageUrl());
+        } else if (portfolio.getPortfolioImages().isEmpty()) {
+            // 모든 이미지가 삭제된 경우 썸네일 URL 제거
+            portfolio.updateThumbnailUrl(null);
+            log.info("모든 이미지 삭제로 인한 썸네일 URL 제거");
+        }
+
+        Portfolio savedPortfolio = portfolioRepository.save(portfolio);
+        log.info("포트폴리오 이미지 삭제 완료 - imageId: {}", imageId);
+        return PortfolioResponseDto.from(savedPortfolio);
+    }
+
+    /**
+     * 내 포트폴리오 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<PortfolioResponseDto> getMyPortfolios(Long userId) {
+        validateDesigner(userId);
+
+        // 먼저 포트폴리오 기본 정보를 조회
+        List<Portfolio> portfolios = portfolioRepository.findByDesignerId(userId);
+
+        // 각 포트폴리오에 대해 이미지와 카테고리를 별도로 로드
+        portfolios.forEach(this::loadPortfolioImagesAndCategories);
+
+        return portfolios.stream()
+                .map(PortfolioResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 특정 포트폴리오 조회
+     */
+    @Transactional(readOnly = true)
+    public PortfolioResponseDto getPortfolio(Long userId, Long portfolioId) {
+        validateDesigner(userId);
+        Portfolio portfolio = getPortfolioByIdAndUserId(portfolioId, userId);
+        return PortfolioResponseDto.from(portfolio);
+    }
+
+    /**
+     * 포트폴리오 삭제
+     */
+    public void deletePortfolio(Long userId, Long portfolioId) {
+        validateDesigner(userId);
+        Portfolio portfolio = getPortfolioByIdAndUserId(portfolioId, userId);
+
+        // 포트폴리오와 연관된 이미지들도 S3에서 삭제
+        for (PortfolioImage image : portfolio.getPortfolioImages()) {
+            try {
+                String fileName = extractFileNameFromUrl(image.getImageUrl());
+                awsS3Service.deleteFile(fileName);
+            } catch (Exception e) {
+                log.warn("S3 이미지 삭제 실패: {}", image.getImageUrl(), e);
+            }
+        }
+
+        portfolioRepository.delete(portfolio);
+        log.info("포트폴리오 삭제 완료 - portfolioId: {}", portfolioId);
+    }
+
+    /**
+     * 디자이너 유효성 검증
+     */
+    private User validateDesigner(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getUserType() != UserType.DESIGNER) {
+            throw new BadRequestException(ErrorCode.INVALID_USER_TYPE);
+        }
+
+        return user;
+    }
+
+    /**
+     * 새 포트폴리오 생성
+     */
+    private Portfolio createNewPortfolio(User designer, PortfolioRequestDto request) {
+        Portfolio portfolio = Portfolio.builder()
+                .designer(designer)
+                .title(request.title())
+                .description(request.description())
+                .build();
+
+        // 디자인 카테고리 설정
+        if (request.designCategories() != null && !request.designCategories().isEmpty()) {
+            portfolio.setDesignCategories(request.designCategories());
+        }
+
+        return portfolioRepository.save(portfolio);
+    }
+
+    /**
+     * 기존 포트폴리오 정보 업데이트
+     */
+    private Portfolio updatePortfolioInfo(Portfolio portfolio, PortfolioRequestDto request) {
+        // 기본 정보 업데이트
+        portfolio.updatePortfolioInfo(request.title(), request.description());
+
+        // 디자인 카테고리 업데이트
+        if (request.designCategories() != null) {
+            portfolio.setDesignCategories(request.designCategories());
+        }
+
+        return portfolioRepository.save(portfolio);
+    }
+
+    private Portfolio getPortfolioByIdAndUserId(Long portfolioId, Long userId) {
+        // 먼저 포트폴리오 기본 정보를 조회
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.PORTFOLIO_NOT_FOUND));
+
+        // 포트폴리오 소유자 검증
+        if (!portfolio.getDesigner().getId().equals(userId)) {
+            throw new BadRequestException(ErrorCode.PORTFOLIO_ACCESS_DENIED);
+        }
+
+        // 이미지와 카테고리를 별도로 로드 (MultipleBagFetchException 방지)
+        loadPortfolioImagesAndCategories(portfolio);
+
+        return portfolio;
+    }
+
+    /**
+     * 포트폴리오의 이미지와 카테고리를 별도로 로드
+     */
+    private void loadPortfolioImagesAndCategories(Portfolio portfolio) {
+        // Hibernate.initialize를 사용하여 컬렉션 초기화
+        org.hibernate.Hibernate.initialize(portfolio.getPortfolioImages());
+        org.hibernate.Hibernate.initialize(portfolio.getDesignCategories());
+    }
+
+    /**
+     * 포트폴리오의 썸네일을 ID가 가장 작은 이미지로 업데이트
+     */
+    private void updateThumbnailToFirstImage(Portfolio portfolio) {
+        // ID가 가장 작은 이미지 찾기
+        portfolio.getPortfolioImages().stream()
+                .min(Comparator.comparingLong(img -> img.getId() != null ? img.getId() : Long.MAX_VALUE))
+                .ifPresent(firstImage -> {
+                    // 새로운 썸네일 설정을 위해 DB에서 업데이트
+                    portfolioImageRepository.updateThumbnailStatus(portfolio.getId(), firstImage.getId());
+
+                    // 포트폴리오 썸네일 URL 업데이트
+                    portfolio.updateThumbnailUrl(firstImage.getImageUrl());
+
+                    log.info("새로운 썸네일 설정 완료 - imageId: {}, imageUrl: {}",
+                            firstImage.getId(), firstImage.getImageUrl());
+                });
+    }
+
+    private String extractFileNameFromUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty()) {
+            return "";
+        }
+        return imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
+    }
+}


### PR DESCRIPTION
1. 포트폴리오 관련 기능 완성
    - 디자이너가 포트폴리오를 등록 시 제목, 카테고리, 상세 설명을 작성할 수 있음
    - 작업물 첨부를 위해 여러 이미지 등록 가능
    - 가장 첫 번째로 등록한 이미지가 포트폴리오 썸네일로 설정됨
    - 포트폴리오 이미지 ID가 적은 순서대로 이미지를 정렬해서 사용자에게 보여줄 수 있도록 함

2. DesignStyle 내용
    - AI 추천 정보에 포함될 카테고리 포함 완료
    - SIMPLE("심플한"), WARM("따뜻한"), FANCY("화려한"), NEAT("산뜻한"), TRANQUIL("차분한"), VINTAGE("빈티지"), RETRO("레트로"), CUTE("귀여운"), LOVELY("러블리"), REFRESHING("청량한"), NATURAL("자연스러운"), LUXURIOUS("고급스러운"), MODERN("현대적인"), CLASSIC("클래식한"), EMOTIONAL("감성적인")

3. 불필요한 주석 제거
    - 코드 가독성 향상을 위해 불필요한 주석은 제거함